### PR TITLE
`pos` argument for genotype label position

### DIFF
--- a/R/plotSegregation.R
+++ b/R/plotSegregation.R
@@ -19,7 +19,7 @@
 #' @export
 plotSegregation = function(x, affected = NULL, unknown = NULL, proband = NULL,
                            carriers = NULL, homozygous = NULL, noncarriers = NULL, cex = 1,
-                           margins = 1, pos = 3, ...) {
+                           margins = 1, pos.geno = "bottom", pos.arrow = "bottomleft", ...) {
 
   # Input checks
   allids = c(proband, affected, unknown, carriers, noncarriers, homozygous)
@@ -70,31 +70,30 @@ plotSegregation = function(x, affected = NULL, unknown = NULL, proband = NULL,
   p$y = p$y[internalID(x, ids = 1:pedsize(x))]
 
   # Genotype label position
-  if(pos %in% c(2,4)) {
-    dist = -3
-    offset = 0.75
-  }
-  else  {
-    pos = 3
-    dist = +3.25
-    offset = 0
-  }
-  vdist = p$boxh + dist * abs(strheight("M", cex = cex))  # vertical dist from top of symbol to "+"
+  lpos = switch(pos.geno,
+                "topleft" = c(-3, 2, 0.75),
+                "topright" = c(-3, 4, 0.75),
+                c(3.25, 3, 0)
+  )
+  vdist = p$boxh + lpos[1] * abs(strheight("M", cex = cex))  # vertical dist from top of symbol to "+"
 
   if(!is.null(carriers))
-    text(p$x[carriers], p$y[carriers] + vdist, labels = "+", cex = cex*1.5, font = 1, pos = pos, offset = offset)
+    text(p$x[carriers], p$y[carriers] + vdist, labels = "+", cex = cex*1.5, font = 1, pos = lpos[2], offset = lpos[3])
 
   if(!is.null(homozygous))
-    text(p$x[homozygous], p$y[homozygous] + vdist, labels = "++", cex = cex*1.5, font = 1, pos = pos, offset = offset)
+    text(p$x[homozygous], p$y[homozygous] + vdist, labels = "++", cex = cex*1.5, font = 1, pos = lpos[2], offset = lpos[3])
 
   if(!is.null(noncarriers))
-    text(p$x[noncarriers], p$y[noncarriers] + vdist, labels = "-", cex = cex*1.5, font = 1, pos = pos, offset = offset)
+    text(p$x[noncarriers], p$y[noncarriers] + vdist, labels = "-", cex = cex*1.5, font = 1, pos = lpos[2], offset = lpos[3])
 
   # proband arrow
   if(hasProband) {
-    corner.x = p$x[proband] - .5*p$boxw
-    corner.y = p$y[proband] + p$boxh
-    arrows(corner.x - 1.7*p$boxw, corner.y + 0.9*p$boxh, corner.x - .5*p$boxw, corner.y ,
+    x.mod = ifelse(pos.arrow %in% c("topright", "bottomright"), +1, -1)
+    y.mod = ifelse(pos.arrow %in% c("topleft", "topright"), 0, 1)
+    corner.x = p$x[proband] + .5*x.mod*p$boxw
+    corner.y = p$y[proband] + y.mod*p$boxh
+    arrows(corner.x + 1.7*x.mod*p$boxw, corner.y + 0.9*y.mod*p$boxh - 0.9*(1-y.mod)*p$boxh,
+           corner.x + .5*x.mod*p$boxw, corner.y,
            lwd = 2, length = .15, xpd = NA)
   }
 

--- a/R/plotSegregation.R
+++ b/R/plotSegregation.R
@@ -19,7 +19,7 @@
 #' @export
 plotSegregation = function(x, affected = NULL, unknown = NULL, proband = NULL,
                            carriers = NULL, homozygous = NULL, noncarriers = NULL, cex = 1,
-                           margins = 1, ...) {
+                           margins = 1, pos = 3, ...) {
 
   # Input checks
   allids = c(proband, affected, unknown, carriers, noncarriers, homozygous)
@@ -69,16 +69,26 @@ plotSegregation = function(x, affected = NULL, unknown = NULL, proband = NULL,
   p$x = p$x[internalID(x, ids = 1:pedsize(x))]
   p$y = p$y[internalID(x, ids = 1:pedsize(x))]
 
-  vdist = p$boxh + 3.25 * abs(strheight("M", cex = cex))  # vertical dist from top of symbol to "+"
+  # Genotype label position
+  if(pos %in% c(2,4)) {
+    dist = -3
+    offset = 0.75
+  }
+  else  {
+    pos = 3
+    dist = +3.25
+    offset = 0
+  }
+  vdist = p$boxh + dist * abs(strheight("M", cex = cex))  # vertical dist from top of symbol to "+"
 
   if(!is.null(carriers))
-    text(p$x[carriers], p$y[carriers] + vdist, labels = "+", cex = cex*1.5, font = 1, pos = 3, offset = 0)
+    text(p$x[carriers], p$y[carriers] + vdist, labels = "+", cex = cex*1.5, font = 1, pos = pos, offset = offset)
 
   if(!is.null(homozygous))
-    text(p$x[homozygous], p$y[homozygous] + vdist, labels = "++", cex = cex*1.5, font = 1, pos = 3, offset = 0)
+    text(p$x[homozygous], p$y[homozygous] + vdist, labels = "++", cex = cex*1.5, font = 1, pos = pos, offset = offset)
 
   if(!is.null(noncarriers))
-    text(p$x[noncarriers], p$y[noncarriers] + vdist, labels = "-", cex = cex*1.5, font = 1, pos = 3, offset = 0)
+    text(p$x[noncarriers], p$y[noncarriers] + vdist, labels = "-", cex = cex*1.5, font = 1, pos = pos, offset = offset)
 
   # proband arrow
   if(hasProband) {

--- a/R/plotSegregation.R
+++ b/R/plotSegregation.R
@@ -77,10 +77,11 @@ plotSegregation = function(x, affected = NULL, unknown = NULL, proband = NULL,
 
   # Genotype label position
   lpos = switch(pos.geno,
-                "topleft" = c(-3, 2, 0.75),
-                "topright" = c(-3, 4, 0.75),
-                c(3.25, 3, 0)
-  )
+                bottom = c(3.25, 3, 0),
+                topleft = c(-3, 2, 0.75),
+                topright = c(-3, 4, 0.75),
+                stop2('`pos.geno` must be either "bottom" , "topleft" or "topright": ', pos.geno))
+
   vdist = p$boxh + lpos[1] * abs(strheight("M", cex = cex))  # vertical dist from top of symbol to "+"
 
   if(!is.null(carriers))
@@ -94,12 +95,19 @@ plotSegregation = function(x, affected = NULL, unknown = NULL, proband = NULL,
 
   # proband arrow
   if(hasProband) {
-    x.mod = ifelse(pos.arrow %in% c("topright", "bottomright"), +1, -1)
-    y.mod = ifelse(pos.arrow %in% c("topleft", "topright"), 0, 1)
-    corner.x = p$x[proband] + .5*x.mod*p$boxw
-    corner.y = p$y[proband] + y.mod*p$boxh
-    arrows(corner.x + 1.7*x.mod*p$boxw, corner.y + 0.9*y.mod*p$boxh - 0.9*(1-y.mod)*p$boxh,
-           corner.x + .5*x.mod*p$boxw, corner.y,
+    mod = switch(pos.arrow,
+           bottomleft = list(x = -1, y = 1),
+           bottomright = list(x = 1, y = 1),
+           topleft = list(x = -1, y = 0),
+           topright = list(x = 1, y = 0),
+           stop2('`pos.arrow` must be either "bottomleft", "bottomright", "topleft" or "topright": ', pos.arrow))
+
+    corner.x = p$x[proband] + .5*mod$x*p$boxw
+    corner.y = p$y[proband] + mod$y*p$boxh
+    arrows(x0 = corner.x + 1.7*mod$x*p$boxw,
+           y0 = corner.y + 0.9*mod$y*p$boxh - 0.9*(1-mod$y)*p$boxh,
+           x1 = corner.x + .5*mod$x*p$boxw,
+           y1 = corner.y,
            lwd = 2, length = .15, xpd = NA)
   }
 

--- a/R/plotSegregation.R
+++ b/R/plotSegregation.R
@@ -4,15 +4,21 @@
 #'
 #' @inheritParams FLB
 #' @param cex,margins Arguments passed on to [pedtools::plot.ped()].
+#' @param pos.geno Position of genotype labels relative to pedigree symbols;
+#'   either "bottom" (default), "topleft" or "topright".
+#' @param pos.arrow Position of the proband arrow; either "bottomleft",
+#'   "bottomright", "topleft" or "topright".
 #'
 #' @examples
 #'
-#' x = nuclearPed(2)
-#' plotSegregation(x, affected = 3:4, unknown = 1:2, proband = 3, carriers = 3:4)
+#' x = cousinPed(1)
+#' plotSegregation(x, affected = c(3,6,8), unknown = 1, carrier = 2:5,
+#'                 homozygous = 8, noncarriers = 6:7, proband = 8)
 #'
-#' y = cousinPed(1, child = TRUE)
-#' plotSegregation(y, affected = 9, unknown = 1:2, proband = 9,
-#'                 homozygous = 9, deceased = 1:2)
+#' # Different placement of genotypes and proband arrow
+#' plotSegregation(x, affected = c(3,6,8), unknown = 1, carrier = 2:5,
+#'                 homozygous = 8, noncarriers = 6:7, proband = 8,
+#'                 pos.geno = "topleft", pos.arrow = "bottomright")
 #'
 #' @importFrom graphics arrows strheight text
 #' @importFrom utils packageVersion

--- a/man/plotSegregation.Rd
+++ b/man/plotSegregation.Rd
@@ -12,10 +12,10 @@ plotSegregation(
   carriers = NULL,
   homozygous = NULL,
   noncarriers = NULL,
-  pos.geno = c("bottom", "topleft", "topright"),
-  pos.arrow = c("bottomleft", "topleft", "topright", "bottomright"),
   cex = 1,
   margins = 1,
+  pos.geno = "bottom",
+  pos.arrow = "bottomleft",
   ...
 )
 }
@@ -38,10 +38,13 @@ labels of pedigree members known to carry two copies of the variant in question.
 \item{noncarriers}{A character vector (or coercible to such), containing the
 ID labels of pedigree members known \emph{not} to carry the variant in question.}
 
-\item{pos.geno, pos.arrow}{Character arguments specifying the positions of the
-genotype labels and the proband indicator.}
-
 \item{cex, margins}{Arguments passed on to \code{\link[pedtools:plot.ped]{pedtools::plot.ped()}}.}
+
+\item{pos.geno}{Position of genotype labels relative to pedigree symbols;
+either "bottom" (default), "topleft" or "topright".}
+
+\item{pos.arrow}{Position of the proband arrow; either "bottomleft",
+"bottomright", "topleft" or "topright".}
 
 \item{...}{Optional plot parameters passed on to \code{\link[pedtools:plot.ped]{pedtools::plot.ped()}}.}
 }
@@ -50,11 +53,13 @@ Plots a pedigree showing the segregation of a variant.
 }
 \examples{
 
-x = nuclearPed(2)
-plotSegregation(x, affected = 3:4, unknown = 1:2, proband = 3, carriers = 3:4)
+x = cousinPed(1)
+plotSegregation(x, affected = c(3,6,8), unknown = 1, carrier = 2:5,
+                homozygous = 8, noncarriers = 6:7, proband = 8)
 
-y = cousinPed(1, child = TRUE)
-plotSegregation(y, affected = 9, unknown = 1:2, proband = 9,
-                homozygous = 9, deceased = 1:2)
+# Different placement of genotypes and proband arrow
+plotSegregation(x, affected = c(3,6,8), unknown = 1, carrier = 2:5,
+                homozygous = 8, noncarriers = 6:7, proband = 8,
+                pos.geno = "topleft", pos.arrow = "bottomright")
 
 }

--- a/man/plotSegregation.Rd
+++ b/man/plotSegregation.Rd
@@ -12,6 +12,8 @@ plotSegregation(
   carriers = NULL,
   homozygous = NULL,
   noncarriers = NULL,
+  pos.geno = c("bottom", "topleft", "topright"),
+  pos.arrow = c("bottomleft", "topleft", "topright", "bottomright"),
   cex = 1,
   margins = 1,
   ...
@@ -35,6 +37,9 @@ labels of pedigree members known to carry two copies of the variant in question.
 
 \item{noncarriers}{A character vector (or coercible to such), containing the
 ID labels of pedigree members known \emph{not} to carry the variant in question.}
+
+\item{pos.geno, pos.arrow}{Character arguments specifying the positions of the
+genotype labels and the proband indicator.}
 
 \item{cex, margins}{Arguments passed on to \code{\link[pedtools:plot.ped]{pedtools::plot.ped()}}.}
 


### PR DESCRIPTION
I think something like this may come in handy?

``` r
library(pedtools)
source("/home/chrcarrizosa/segregatr/R/plotSegregation.R")
x = cousinPed(1)
plotSegregation(x, affected = c(3,6,8), unknown = 1, carrier = 2:5,
                homozygous = 8, noncarriers = 6:7, proband = 8, pos = 2)
```

![](https://i.imgur.com/sEq9fJB.png)<!-- -->

``` r
plotSegregation(x, affected = c(3,6,8), unknown = 1, carrier = 2:5,
                homozygous = 8, noncarriers = 6:7, proband = 8, pos = 4)
```

![](https://i.imgur.com/Sg4WbVt.png)<!-- -->

<sup>Created on 2023-05-25 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
